### PR TITLE
clipboard curl fix for Windows

### DIFF
--- a/HttpInspect.as
+++ b/HttpInspect.as
@@ -27,11 +27,10 @@ RequestInfo@ AddRequestInfo(const string &in method)
 
 string CommandLineSafe(const string &in str)
 {
-#if WINDOWS 
-	return "\"" + str.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
-#elif LINUX
-	return "'" + str.Replace("\\", "\\\\").Replace("'", "'\\''") + "'";
-#endif
+	if (Setting_UseDoubleQuotes)
+		return "\"" + str.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+	else
+		return "'" + str.Replace("\\", "\\\\").Replace("'", "'\\''") + "'";
 }
 
 void RenderInterface()

--- a/HttpInspect.as
+++ b/HttpInspect.as
@@ -27,7 +27,11 @@ RequestInfo@ AddRequestInfo(const string &in method)
 
 string CommandLineSafe(const string &in str)
 {
-	return str.Replace("\\", "\\\\").Replace("'", "'\\''");
+#if WINDOWS 
+	return "\"" + str.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+#elif LINUX
+	return "'" + str.Replace("\\", "\\\\").Replace("'", "'\\''") + "'";
+#endif
 }
 
 void RenderInterface()
@@ -106,16 +110,16 @@ void RenderInterface()
 					if (request.m_headers != "") {
 						auto lines = request.m_headers.Split("\n");
 						for (uint j = 0; j < lines.Length; j++) {
-							curl += " -H '" + CommandLineSafe(lines[j]) + "'";
+							curl += " -H " + CommandLineSafe(lines[j]);
 						}
 					}
 					if (request.m_resource != "") {
-						curl += " -d '" + CommandLineSafe(request.m_resource) + "'";
+						curl += " -d " + CommandLineSafe(request.m_resource);
 					}
 					if (request.m_url.Contains("[") || request.m_url.Contains("{")) {
 						curl += " -g";
 					}
-					curl += " '" + CommandLineSafe(request.m_url) + "'";
+					curl += " " + CommandLineSafe(request.m_url);
 					IO::SetClipboard(curl);
 				}
 

--- a/Settings.as
+++ b/Settings.as
@@ -1,0 +1,2 @@
+[Setting category="General" name="Use double quotes" description="Check this option if you are using cmd.exe, keep it unchecked for everything else"]
+bool Setting_UseDoubleQuotes = false;


### PR DESCRIPTION
A quick fix to make copied curl command to work for Windows. Since this [commit](https://github.com/codecat/tm-http-inspect/commit/10f47ffd29b18381ebf0e7bf49a48c598c735419) the copied curl command has stopped working for Windows, since strings have to be enquoted with double quotes.